### PR TITLE
Align index name validation in custom resources with Splunk docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the splunk cookbook.
 
 ## Unreleased
 
+- Align index name validation in splunk_monitor and splunk_index resources with [Splunk docs](https://docs.splunk.com/Documentation/Splunk/8.2.2/Indexer/Setupmultipleindexes)
+
 ## 9.1.0 - *2021-09-23*
 
 - Add SUSE support

--- a/README.md
+++ b/README.md
@@ -456,11 +456,7 @@ Upon convergence, this resource will add a new stanza to the `indexes.conf` file
 
 - `index_name` - this is the String naming each Splunk index. The resource will verify that the name of the index satisifies Splunk's naming requirements, which are below:
 
->>>
-Index names must consist of only numbers, lowercase letters, underscores,
-and hyphens. They cannot begin with an underscore or hyphen, or contain
-the word "kvstore".
->>>
+  > User-defined index names must consist of only numbers, lowercase letters, underscores, and hyphens. They cannot begin with an underscore or hyphen, or contain the word "kvstore".
 
 - `indexes_conf_path` - this is the target path and filename to the `indexes.conf`
 - `backup` - similar to the backup property of other file/template resources in chef, this specifies a number of backup files to retain or false to disable (Default: 5)
@@ -472,7 +468,7 @@ A test recipe is embedded in this cookbook. Please look at `test/fixtures/cookbo
 
 ### splunk_monitor
 
-Adds a Splunk monitor stanza into a designated `inputs.conf` file in a "chef-erized" way using standard Chef DSL vernacular. This resource also validates supported monitors and indexes as documented by Splunk. The dictionary is created from documentation on [Splunk's website](https://docs.splunk.com/@documentation/Splunk/8.0.2/Data/Listofpretrainedsourcetypes).
+Adds a Splunk monitor stanza into a designated `inputs.conf` file in a "chef-erized" way using standard Chef DSL vernacular. This resource also validates supported monitors and index names as documented by Splunk. The dictionary is created from documentation on [Splunk's website](https://docs.splunk.com/@documentation/Splunk/8.0.2/Data/Listofpretrainedsourcetypes).
 
 Upon convergence, this resource will add a new stanza to the inputs.conf file, as needed, and modify or add new lines to the section based on properties given to the resource. If the current stanza in the inputs.conf file has any extra lines that are not listed as a valid property in this resource, those lines are automatically removed.
 

--- a/resources/splunk_index.rb
+++ b/resources/splunk_index.rb
@@ -18,10 +18,10 @@ provides :splunk_index
 unified_mode true
 resource_name :splunk_index
 
-# Index names must consist of only numbers, lowercase letters, underscores,
-# and hyphens. They cannot begin with an underscore or hyphen, or contain
-# the word "kvstore".
-property :index_name, kind_of: String, name_property: true, regex: /^[^_-][0-9a-zA-Z_=]+/,
+# User-defined index names must consist of only numbers, lowercase letters,
+# underscores, and hyphens. They cannot begin with an underscore or hyphen,
+# or contain the word "kvstore".
+property :index_name, kind_of: String, name_property: true, regex: /^[0-9a-z][0-9a-z_-]+$/,
                       coerce: proc { |index| index.gsub(/kvstore/, '') }
 property :indexes_conf_path, kind_of: String, regex: %r{^/.*/indexes\.conf$}, desired_state: false, required: true
 property :backup, kind_of: [FalseClass, Integer], default: 5, desired_state: false

--- a/resources/splunk_monitor.rb
+++ b/resources/splunk_monitor.rb
@@ -75,8 +75,12 @@ property :backup, kind_of: [FalseClass, Integer], default: 5, desired_state: fal
 # These resource properties are drawn from Splunk's @documentation.
 # Refer to https://docs.splunk.com/@documentation/Splunk/8.0.2/Data/Monitorfilesanddirectorieswithinputs.conf
 # for more detailed description of these properties
+#
+# Refer to https://docs.splunk.com/Documentation/Splunk/latest/Indexer/Setupmultipleindexes
+# for user-defined index name requirements--note that Splunk-standard internal
+# indexes do start with an underscore
 property :host, kind_of: String, default: nil
-property :index, kind_of: String, default: '_internal', regex: /^[^-][0-9a-zA-Z_=]+/,
+property :index, kind_of: String, default: '_internal', regex: /^[0-9a-z_][0-9a-z_-]+$/,
                  coerce: proc { |index| index.gsub(/kvstore/, '') }
 property :sourcetype, kind_of: String, equal_to: pretrained_sourcetypes
 property :queue, kind_of: String, equal_to: %w(parsingQueue indexQueue), default: 'parsingQueue'

--- a/resources/splunk_monitor.rb
+++ b/resources/splunk_monitor.rb
@@ -66,12 +66,6 @@ dictionary = {
 
 pretrained_sourcetypes = dictionary.values.flatten.sort.uniq
 
-builtin_indexes = %w(
-  _internal access_combined access_combined_wcookie apache_error
-  catalina cisco_syslog history linux_messages_syslog linux_secure
-  log4j main os postfix_syslog rabbitmq sample shared_json splunklogger
-)
-
 # these properties are specific to this resource
 property :monitor_name, kind_of: String, name_property: true, regex: %r{^monitor:///.*},
                         coerce: proc { |m| "monitor://#{m}" }
@@ -82,7 +76,8 @@ property :backup, kind_of: [FalseClass, Integer], default: 5, desired_state: fal
 # Refer to https://docs.splunk.com/@documentation/Splunk/8.0.2/Data/Monitorfilesanddirectorieswithinputs.conf
 # for more detailed description of these properties
 property :host, kind_of: String, default: nil
-property :index, kind_of: String, equal_to: builtin_indexes, default: '_internal'
+property :index, kind_of: String, default: '_internal', regex: /^[^-][0-9a-zA-Z_=]+/,
+                 coerce: proc { |index| index.gsub(/kvstore/, '') }
 property :sourcetype, kind_of: String, equal_to: pretrained_sourcetypes
 property :queue, kind_of: String, equal_to: %w(parsingQueue indexQueue), default: 'parsingQueue'
 property :_TCP_ROUTING, kind_of: String, default: '*'

--- a/test/fixtures/cookbooks/test/recipes/splunk_monitor.rb
+++ b/test/fixtures/cookbooks/test/recipes/splunk_monitor.rb
@@ -5,9 +5,20 @@ file '/var/log/httpd/access.log' do
   action :create_if_missing
 end
 
+file '/var/log/httpd/error.log' do
+  action :create_if_missing
+end
+
 splunk_monitor '/var/log/httpd/access.log' do
   inputs_conf_path "#{splunk_dir}/etc/apps/SplunkUniversalForwarder/default/inputs.conf"
   sourcetype 'access_combined'
   index 'access_combined'
   only_if { ::File.exist?('/var/log/httpd/access.log') }
+end
+
+splunk_monitor '/var/log/httpd/error.log' do
+  inputs_conf_path "#{splunk_dir}/etc/apps/SplunkUniversalForwarder/default/inputs.conf"
+  sourcetype 'apache_error'
+  index 'alert-web_1'
+  only_if { ::File.exist?('/var/log/httpd/error.log') }
 end

--- a/test/integration/client-resources/inspec/client_resources_spec.rb
+++ b/test/integration/client-resources/inspec/client_resources_spec.rb
@@ -28,4 +28,5 @@ end
 describe ini('/opt/splunkforwarder/etc/apps/SplunkUniversalForwarder/default/inputs.conf') do
   its(['monitor:///var/log/httpd/access.log', 'index']) { should cmp /access_combined/ }
   its(['monitor:///var/log/httpd/access.log', 'sourcetype']) { should match /access_combined/ }
+  its(['monitor:///var/log/httpd/error.log', 'index']) { should cmp 'alert-web_1' }
 end


### PR DESCRIPTION
# Description

Usability improvements to the _splunk_monitor_ and _splunk_index_ custom resources, accepting valid (user-defined) index names while rejecting invalid index names, as per Splunk's (user-defined) index name requirements and standard internal index names.

## Issues Resolved

#216 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
