### PR TITLE
Require Chef 16 for chef-vault functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the splunk cookbook.
 
 ## Unreleased
 
+- Require Chef 16 for Chef Vault functionality
+
 ## 8.0.0 - *2021-09-23*
 
 - Remove `systemd?` method and use internal one instead

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Manage Splunk Enterprise or Splunk Universal Forwarder'
 version           '8.0.0'
 source_url        'https://github.com/sous-chefs/chef-splunk'
 issues_url        'https://github.com/sous-chefs/chef-splunk/issues'
-chef_version      '>= 15.5'
+chef_version      '>= 16.0'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
# Description

Require Chef 16 for chef-vault functionality
We previously removed the chef-vault cookbook but did not bump the metadata version high enough. 

## Issues Resolved

Chef 16 is required for built-in chef-vault functionality

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
